### PR TITLE
Update CDK CLI to version 2.1005.0 for compatibility with CDK lib 2.195.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This solution consists of the following components:
 
 - [Node.js](https://nodejs.org/) (v22 LTS or later)
 - [AWS CLI](https://aws.amazon.com/cli/) (latest version)
-- [AWS CDK](https://aws.amazon.com/cdk/) (v2.170.0 or later)
+- [AWS CDK](https://aws.amazon.com/cdk/) (v2.195.0 or later)
 - [Docker](https://www.docker.com/) (latest version, installed and running, required for Python Lambda deployment)
 - AWS account with appropriate IAM permissions
 - Amazon OpenSearch Service service-linked role (see note below)

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -27,7 +27,7 @@ The application is built using AWS CDK and consists of several layers:
 
 - Node.js 18.x or later
 - AWS CLI configured with appropriate credentials
-- AWS CDK installed (v2.170.0 or later)
+- AWS CDK installed (v2.195.0 or later)
 - Docker installed and running (latest version, required for Python Lambda function deployment)
 - Amazon OpenSearch Service service-linked role (see below)
 

--- a/infrastructure/package-lock.json
+++ b/infrastructure/package-lock.json
@@ -22,7 +22,7 @@
       "devDependencies": {
         "@types/jest": "29.5.4",
         "@types/node": "20.5.9",
-        "aws-cdk": "2.178.2",
+        "aws-cdk": "2.1005.0",
         "dotenv": "16.4.7",
         "jest": "29.6.4",
         "ts-jest": "29.1.1",
@@ -323,46 +323,6 @@
         "url": "https://opencollective.com/pnpm"
       }
     },
-    "node_modules/@aws/pdk/node_modules/@pnpm/git-utils/node_modules/execa": {
-      "name": "safe-execa",
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/safe-execa/-/safe-execa-0.1.2.tgz",
-      "integrity": "sha512-vdTshSQ2JsRCgT8eKZWNJIL26C6bVqy1SOmuCMlKHegVeo8KYRobRrefOdUq9OozSPUUiSxrylteeRmLOMFfWg==",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@zkochan/which": "^2.0.3",
-        "execa": "^5.1.1",
-        "path-name": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/@pnpm/git-utils/node_modules/execa/node_modules/execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
     "node_modules/@aws/pdk/node_modules/@pnpm/lockfile-file": {
       "version": "8.1.8",
       "inBundle": true,
@@ -394,20 +354,6 @@
       },
       "peerDependencies": {
         "@pnpm/logger": "^5.0.0"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/@pnpm/lockfile-file/node_modules/js-yaml": {
-      "name": "@zkochan/js-yaml",
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.6.tgz",
-      "integrity": "sha512-nzvgl3VfhcELQ8LyVrYOru+UtAy1nrygk2+AGbTm8a5YcO6o8lSjAT+pfg3vJWxIoZKOUhrK6UU7xW/+00kQrg==",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@aws/pdk/node_modules/@pnpm/lockfile-types": {
@@ -696,6 +642,11 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/@aws/pdk/node_modules/arg": {
+      "version": "5.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/@aws/pdk/node_modules/argparse": {
       "version": "2.0.1",
       "inBundle": true,
@@ -749,6 +700,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/@aws/pdk/node_modules/builtins": {
@@ -829,6 +794,11 @@
       "engines": {
         "node": ">=12.17"
       }
+    },
+    "node_modules/@aws/pdk/node_modules/concat-map": {
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/@aws/pdk/node_modules/create-require": {
       "version": "1.1.1",
@@ -990,13 +960,6 @@
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
-    },
-    "node_modules/@aws/pdk/node_modules/error-ex/node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/@aws/pdk/node_modules/es-abstract": {
       "version": "1.23.5",
@@ -1297,6 +1260,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/@aws/pdk/node_modules/glob": {
+      "version": "8.1.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@aws/pdk/node_modules/globalthis": {
       "version": "1.0.4",
       "inBundle": true,
@@ -1478,6 +1459,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/@aws/pdk/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/@aws/pdk/node_modules/is-async-function": {
       "version": "2.0.0",
@@ -1840,6 +1826,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@aws/pdk/node_modules/lines-and-columns": {
+      "version": "2.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/@aws/pdk/node_modules/load-json-file": {
       "version": "6.2.0",
       "inBundle": true,
@@ -1850,16 +1844,6 @@
         "strip-bom": "^4.0.0",
         "type-fest": "^0.6.0"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/load-json-file/node_modules/type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-      "inBundle": true,
-      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=8"
       }
@@ -1982,16 +1966,6 @@
         "url": "https://github.com/sindresorhus/mem?sponsor=1"
       }
     },
-    "node_modules/@aws/pdk/node_modules/mem/node_modules/mimic-fn": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
-      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@aws/pdk/node_modules/merge-stream": {
       "version": "2.0.0",
       "inBundle": true,
@@ -2003,6 +1977,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/minimatch": {
+      "version": "3.1.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@aws/pdk/node_modules/ms": {
@@ -2030,29 +2015,6 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/normalize-package-data/node_modules/hosted-git-info": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.3.tgz",
-      "integrity": "sha512-HVJyzUrLIL1c0QmviVh5E8VGyUS7xCFPS6yydaVd1UegW+ibV/CohqTH9MkOLDp5o+rb82DMo77PTuc9F/8GKw==",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^7.5.1"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/normalize-package-data/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@aws/pdk/node_modules/normalize-path": {
@@ -2150,6 +2112,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/@aws/pdk/node_modules/p-limit": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@aws/pdk/node_modules/p-locate": {
       "version": "4.1.0",
       "inBundle": true,
@@ -2159,22 +2135,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/p-locate/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@aws/pdk/node_modules/parse-json": {
@@ -2193,13 +2153,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/@aws/pdk/node_modules/parse-json/node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/@aws/pdk/node_modules/parse-unit": {
       "version": "1.0.1",
@@ -2273,46 +2226,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/read-pkg/node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/@aws/pdk/node_modules/read-pkg/node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/read-pkg/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/read-pkg/node_modules/type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-      "inBundle": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@aws/pdk/node_modules/read-yaml-file": {
@@ -2407,28 +2320,6 @@
       },
       "bin": {
         "rimraf": "bin.js"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@aws/pdk/node_modules/safe-array-concat": {
@@ -2606,41 +2497,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/@aws/pdk/node_modules/streamroller/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/streamroller/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "inBundle": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@aws/pdk/node_modules/streamroller/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/@aws/pdk/node_modules/string.prototype.trim": {
       "version": "1.2.9",
       "inBundle": true,
@@ -2800,13 +2656,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@aws/pdk/node_modules/ts-node/node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/@aws/pdk/node_modules/type-fest": {
       "version": "0.8.1",
@@ -3067,19 +2916,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/@aws/pdk/node_modules/write-file-atomic/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@aws/pdk/node_modules/write-yaml-file": {
       "version": "5.0.0",
       "inBundle": true,
@@ -3120,6 +2956,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4314,9 +4161,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.178.2",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.178.2.tgz",
-      "integrity": "sha512-ojMCMnBGinvDUD6+BOOlUOB9pjsYXoQdFVbf4bvi3dy3nwn557r0j6qDUcJMeikzPJ6YWzfAdL0fYxBZg4xcOg==",
+      "version": "2.1005.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1005.0.tgz",
+      "integrity": "sha512-4ejfGGrGCEl0pg1xcqkxK0lpBEZqNI48wtrXhk6dYOFYPYMZtqn1kdla29ONN+eO2unewkNF4nLP1lPYhlf9Pg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@types/jest": "29.5.4",
     "@types/node": "20.5.9",
-    "aws-cdk": "2.178.2",
+    "aws-cdk": "2.1005.0",
     "dotenv": "16.4.7",
     "jest": "29.6.4",
     "ts-jest": "29.1.1",


### PR DESCRIPTION
- Update aws-cdk from 2.178.2 to 2.1005.0 in package.json
- Update package-lock.json with new CDK CLI dependencies
- Update README.md and infrastructure/README.md to reflect CDK v2.195.0 requirement
- Resolves version compatibility issues between CDK library and CLI
- Tested with successful CDK synthesis and deployment

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
